### PR TITLE
Add json option for get and set functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Get a key. `opts` defaults to
 {
   recursive: false,
   sorted: false,
+  json: false,      // parse value as JSON for this request
   wait: false,
   waitIndex: (none)
 }
@@ -73,6 +74,7 @@ Set a key. `opts` defaults to
 {
   ttl: (none),
   dir: false,
+  json: false,      // stringify value as JSON for this request
   prevExist: (none),
   prevValue: (none),
   prevIndex: (none)

--- a/index.js
+++ b/index.js
@@ -69,7 +69,7 @@ Client.prototype.set = function (key, value, opts, cb) {
   if (typeof opts === 'function') return this.set(key, value, null, opts)
   if (!opts) opts = {}
   if (!cb) cb = noop
-  if (this._json) value = JSON.stringify(value)
+  if (this._json || opts.json) value = JSON.stringify(value)
 
   var form = {}
 
@@ -113,7 +113,12 @@ Client.prototype.get = function (key, opts, cb) {
     qs: qs,
     json: true,
     pool: opts.wait ? false : undefined
-  }, cb)
+  }, function (err, body) {
+    if (err) return cb(err)
+
+    if (opts.json) decodeJSON(body.node);
+    cb(null, body)
+  });
 }
 
 Client.prototype.wait = function (key, opts, cb) {

--- a/test/basic.js
+++ b/test/basic.js
@@ -18,6 +18,16 @@ test('set and get', function (store, t) {
   })
 })
 
+test('set and get with json option', function (store, t) {
+  store.set('etcdjs/test', {hello: 'world'}, {json: true}, function () {
+    store.get('etcdjs/test', {json: true}, function (err, result) {
+      t.ok(!err, 'no error')
+      t.same(result.node.value, {hello: 'world'}, 'result is object that matches set value')
+      t.end()
+    })
+  })
+})
+
 test('del', function (store, t) {
   store.set('etcdjs/test', 'world', function () {
     store.del('etcdjs/test', function (err) {


### PR DESCRIPTION
Thanks for the great library! As I was using it, I ran into a potential improvement dealing with handling of JSON values. I see the global json flag passed into the constructor, but I have some values that aren't JSON so the class level flag set to true doesn't work for me when I'm getting those keys.

This PR adds the json flag to the `get` and `set` function options allowing the values to be parsed/stringified on a per-call basis. I added a test and updated the readme as well. Thanks!
