### PR TITLE
Fixed issue for get when key doesn't exist and json option is true

### DIFF
--- a/index.js
+++ b/index.js
@@ -116,7 +116,7 @@ Client.prototype.get = function (key, opts, cb) {
   }, function (err, body) {
     if (err) return cb(err)
 
-    if (opts.json) decodeJSON(body.node);
+    if (opts.json && body) decodeJSON(body.node);
     cb(null, body)
   });
 }

--- a/test/basic.js
+++ b/test/basic.js
@@ -8,6 +8,14 @@ test('get not found', function (store, t) {
   })
 })
 
+test('get with json option not found', function (store, t) {
+  store.get('etcdjs/test', {json: true}, function (err, result) {
+    t.ok(!err, 'no error')
+    t.ok(!result, 'no result')
+    t.end()
+  })
+})
+
 test('set and get', function (store, t) {
   store.set('etcdjs/test', 'world', function () {
     store.get('etcdjs/test', function (err, result) {


### PR DESCRIPTION
Discovered an issue when using the new json option on get and the key doesn't exist. Fixed the bug and added a test for it.