### PR TITLE
Bumps request to 2.88.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "repository": "mafintosh/etcdjs",
   "dependencies": {
     "roundround": "0.2.0",
-    "request": "2.81.0"
+    "request": "2.88.0"
   },
   "devDependencies": {
     "tape": "^4.6.3"


### PR DESCRIPTION
request's version 2.81.0 was exposed to a [critical security vulnerability](https://github.com/advisories/GHSA-xvch-5gv4-984h) which got fixed in later versions of the request package.
    
This commit bumps request to a stable version.

Looking at [the CHANGELOG](https://github.com/request/request/blob/master/CHANGELOG.md) nothing strikes me as a breaking change that would affect the package